### PR TITLE
Feature/issue191 wipp lib replace inline editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2260,6 +2260,21 @@
         "tslib": "^1.9.0"
       }
     },
+    "@ngneat/edit-in-place": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ngneat/edit-in-place/-/edit-in-place-1.3.1.tgz",
+      "integrity": "sha512-VoCp5aNDeDP8WjcNRRaPjolBLykduyUtwStFeEGMFzHLDkAwPlrazYYQx3ybYzJR0+dT1iImSqtcu++u243taw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
     "@ngtools/webpack": {
       "version": "9.1.13",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-9.1.13.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@flowjs/flow.js": "^2.13.0",
     "@fortawesome/fontawesome-free": "^5.3.1",
     "@ng-bootstrap/ng-bootstrap": "^5.2.2",
+    "@ngneat/edit-in-place": "^1.3.1",
     "@swimlane/ngx-charts": "^12.0.1",
     "@swimlane/ngx-graph": "^7.0.0",
     "@types/flowjs": "0.0.31",
@@ -41,8 +42,10 @@
     "d3": "^3.5.12",
     "dagre": "^0.8.4",
     "dagre-d3": "^0.6.3",
+    "file-saver": "^2.0.2",
     "fs": "0.0.1-security",
     "jexl": "^2.2.2",
+    "keycloak-js": "^8.0.0",
     "marked": "^0.7.0",
     "ngx-json-viewer": "^2.4.0",
     "ngx-schema-form": "^2.6.0",
@@ -54,9 +57,7 @@
     "tslib": "^1.10.0",
     "url-join": "^4.0.1",
     "z-schema": "^3.24.1",
-    "zone.js": "~0.10.2",
-    "file-saver": "^2.0.2",
-    "keycloak-js": "^8.0.0"
+    "zone.js": "~0.10.2"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.901.13",

--- a/projects/wipp-frontend-app/src/environments/environment.ts
+++ b/projects/wipp-frontend-app/src/environments/environment.ts
@@ -9,7 +9,8 @@ export const environment = {
   version: version,
   apiRootUrl: 'http://localhost:8080/api',
   keycloak: {
-      url: 'http://localhost:8081/auth',
+      // url: 'http://localhost:8081/auth',
+      url: 'https://keycloak-ci.aws.labshare.org/auth',
       realm: 'WIPP',
       clientId: 'wipp-public-client'
   },

--- a/projects/wipp-frontend-app/src/environments/environment.ts
+++ b/projects/wipp-frontend-app/src/environments/environment.ts
@@ -9,8 +9,7 @@ export const environment = {
   version: version,
   apiRootUrl: 'http://localhost:8080/api',
   keycloak: {
-      // url: 'http://localhost:8081/auth',
-      url: 'https://keycloak-ci.aws.labshare.org/auth',
+      url: 'http://localhost:8081/auth',
       realm: 'WIPP',
       clientId: 'wipp-public-client'
   },

--- a/projects/wipp-frontend-lib/src/lib/images-collection/images-collection-detail/images-collection-detail.component.css
+++ b/projects/wipp-frontend-lib/src/lib/images-collection/images-collection-detail/images-collection-detail.component.css
@@ -64,3 +64,11 @@
   width: 100%;
   height: 150px;
 }
+
+.form-group {
+  width: fit-content;
+}
+
+button {
+  margin: 5px;
+}

--- a/projects/wipp-frontend-lib/src/lib/images-collection/images-collection-detail/images-collection-detail.component.html
+++ b/projects/wipp-frontend-lib/src/lib/images-collection/images-collection-detail/images-collection-detail.component.html
@@ -5,12 +5,22 @@
       <dl class="row">
         <dt class="col-md-4">Name:</dt>
         <dd class="col-md-8">
-          <!-- <inline-editor type="text" [(ngModel)]="imagesCollection.name"
-                         (onSave)="updateCollectionName($event)" size="20"
-                         name="editableImageCollectionName">
-            {{imagesCollection.name}}
-          </inline-editor> -->
-          {{imagesCollection.name}}
+          <editable 
+            [openBindingEvent]="openBindingEvent"
+            (save)="updateCollectionName()">
+            <ng-template viewMode>{{imagesCollection.name}}</ng-template>
+            <ng-template editMode>
+              <div class="d-flex align-items-baseline">
+                <div class="form-group">
+                  <input             
+                    type="text"
+                    [formControl]="inputButtonsControl"/>
+                </div>
+                <button class="btn btn-success" editableOnSave>Save</button>
+                <button class="btn btn-secondary" editableOnCancel>Cancel</button>
+              </div>
+            </ng-template>
+          </editable>
         </dd>
 
         <dt class="col-md-4">Creation date:</dt>
@@ -437,7 +447,7 @@
 
   <div class="container-fluid topMarge20">
     <div class="row">
-      <div class="col-md-5">
+      <div class="col-md-5"></div>
       <div class="col-md-3 text-right topMarge5">
         <span class="goToSpan">
            <mat-form-field class="inputPage">

--- a/projects/wipp-frontend-lib/src/lib/images-collection/images-collection-detail/images-collection-detail.component.ts
+++ b/projects/wipp-frontend-lib/src/lib/images-collection/images-collection-detail/images-collection-detail.component.ts
@@ -16,6 +16,7 @@ import { Job } from '../../job/job';
 import urljoin from 'url-join';
 import { KeycloakService } from '../../services/keycloack/keycloak.service';
 import { ModalErrorComponent } from '../../modal-error/modal-error.component';
+import { FormControl } from '@angular/forms';
 
 @Component({
   selector: 'app-images-collection-detail',
@@ -50,6 +51,8 @@ export class ImagesCollectionDetailComponent implements OnInit, AfterViewInit {
   goToPageMetadataFiles;
   imageCollectionId = this.route.snapshot.paramMap.get('id');
   sourceCatalogLink = '';
+  inputButtonsControl: FormControl = new FormControl(this.imagesCollection.name);
+  openBindingEvent = 'dblclick';
 
   @ViewChild('browseBtn') browseBtn: ElementRef;
   @ViewChild('browseDirBtn') browseDirBtn: ElementRef;
@@ -133,11 +136,6 @@ export class ImagesCollectionDetailComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit() {
-    // fixme: temporary fix while waiting for 1.0.0 release of ngx-inline-editor
-    // const faRemoveElt = this.elem.nativeElement.querySelector('.fa-remove');
-    // faRemoveElt.classList.remove('fa-remove');
-    // faRemoveElt.classList.add('fa-times');
-
     this.refresh().subscribe(imagesCollection => {
       if (this.canEdit() && !imagesCollection.locked) {
         this.initFlow();
@@ -223,9 +221,9 @@ export class ImagesCollectionDetailComponent implements OnInit, AfterViewInit {
       imagesCollection.numberOfMetadataFiles;
   }
 
-  updateCollectionName(name: string): void {
+  updateCollectionName(): void {
     this.imagesCollectionService.setImagesCollectionName(
-      this.imagesCollection, name).subscribe(imagesCollection => {
+      this.imagesCollection, this.inputButtonsControl.value).subscribe(imagesCollection => {
         this.imagesCollection = imagesCollection;
       });
   }

--- a/projects/wipp-frontend-lib/src/lib/images-collection/images-collection.module.ts
+++ b/projects/wipp-frontend-lib/src/lib/images-collection/images-collection.module.ts
@@ -16,6 +16,7 @@ import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {ImagesCollectionTemplateComponent} from './images-collection-template/images-collection-template.component';
 import { HttpClientModule } from '@angular/common/http';
 import { RouterModule } from '@angular/router';
+import { EditableModule } from '@ngneat/edit-in-place';
 
 @NgModule({
   imports: [
@@ -32,7 +33,8 @@ import { RouterModule } from '@angular/router';
     MatInputModule,
     ReactiveFormsModule,
     MatCheckboxModule,
-    HttpClientModule
+    HttpClientModule,
+    EditableModule
   ],
   entryComponents: [ImagesCollectionNewComponent],
   declarations: [


### PR DESCRIPTION
## What does this PR do?

Removed ngx-inline-editor library (since it does not support angular 9) and added the @ngneat/edit-in-place library which allows the user to edit an images collection name post creation. 

## Related issues

https://github.com/usnistgov/WIPP-frontend/issues/200