### PR TITLE
fix: remove nginx X-Forwarded-* headers

### DIFF
--- a/deploy/docker/default.conf
+++ b/deploy/docker/default.conf
@@ -8,8 +8,6 @@ server {
   location ^~ /api/ {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header Host $http_host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_http_version 1.1;
 
     proxy_pass http://@backend_host@:@backend_port@/api/;
@@ -19,8 +17,6 @@ server {
   location ^~ /pyramid-files/ {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header Host $http_host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_http_version 1.1;
 
     proxy_pass http://@backend_host@:@backend_port@/pyramid-files/;


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Remove recently added nginx X-Forwarded-* headers.
Headers were causing Spring backend to return links URLs for resources in http as opposed to https, causing errors when these links were used in the frontend (for example, calls to get source jobs from data detail pages, pyramid tiles, etc.).

@mohamedOuladi as discussed in your PR, tested on Nist ci


