### PR TITLE
feat: renamed generic data collection endpoint and properties

### DIFF
--- a/projects/wipp-frontend-lib/src/lib/generic-data-collection/generic-data-collection-detail/generic-data-collection-detail.component.ts
+++ b/projects/wipp-frontend-lib/src/lib/generic-data-collection/generic-data-collection-detail/generic-data-collection-detail.component.ts
@@ -23,7 +23,7 @@ export class GenericDataCollectionDetailComponent implements OnInit, AfterViewIn
 
   genericDataCollection: GenericDataCollection = new GenericDataCollection();
   job: Job = null;
-  genericDataId: Observable<string>;
+  genericDataCollectionId: Observable<string>;
   uploadOption = 'regular';
   genericFiles: Observable<GenericFile[]>;
   resultsLengthGenericFiles = 0;
@@ -47,6 +47,9 @@ export class GenericDataCollectionDetailComponent implements OnInit, AfterViewIn
     private router: Router,
     private genericDataCollectionService: GenericDataCollectionService,
     private keycloakService: KeycloakService) {
+    this.genericDataCollectionId = this.route.params.pipe(
+      map(data => data.id)
+    );
     this.genericFilesParamsChange = new BehaviorSubject({
       index: 0,
       size: this.pageSize,
@@ -101,7 +104,7 @@ export class GenericDataCollectionDetailComponent implements OnInit, AfterViewIn
   }
 
   getGenericDataCollection() {
-    return this.genericDataId.pipe(
+    return this.genericDataCollectionId.pipe(
       switchMap(id => this.genericDataCollectionService.getById(id))
     );
   }
@@ -214,8 +217,8 @@ export class GenericDataCollectionDetailComponent implements OnInit, AfterViewIn
 
   makePublicCollection(): void {
     this.genericDataCollectionService.makePublicGenericDataCollection(
-      this.genericDataCollection).subscribe(genericData => {
-        this.genericDataCollection = genericData;
+      this.genericDataCollection).subscribe(genericDataCollection => {
+        this.genericDataCollection = genericDataCollection;
       }, error => {
         const modalRefErr = this.modalService.open(ModalErrorComponent);
         modalRefErr.componentInstance.title = 'Error while changing Collection visibility to public';

--- a/projects/wipp-frontend-lib/src/lib/generic-data-collection/generic-data-collection.service.ts
+++ b/projects/wipp-frontend-lib/src/lib/generic-data-collection/generic-data-collection.service.ts
@@ -13,7 +13,7 @@ import { GenericFile, PaginatedGenericFiles } from './generic-file';
 })
 export class GenericDataCollectionService implements DataService<GenericDataCollection, PaginatedGenericDataCollections> {
 
-  private genericDataCollectionUrl = this.env.apiRootUrl + '/genericDatas';
+  private genericDataCollectionUrl = this.env.apiRootUrl + '/genericDataCollections';
   private genericDataCollectionUiPath = this.env.uiPaths.genericDataCollectionsPath;
 
   constructor(
@@ -39,7 +39,7 @@ export class GenericDataCollectionService implements DataService<GenericDataColl
     }
     return this.http.get<any>(this.genericDataCollectionUrl, httpOptions).pipe(
       map((result: any) => {
-        result.data = result._embedded.genericDatas;
+        result.data = result._embedded.genericDataCollections;
         return result;
       }));
   }
@@ -59,7 +59,7 @@ export class GenericDataCollectionService implements DataService<GenericDataColl
     httpOptions.params = httpParams;
     return this.http.get<any>(this.genericDataCollectionUrl + '/search/findByNameContainingIgnoreCase', httpOptions).pipe(
       map((result: any) => {
-        result.data = result._embedded.genericDatas;
+        result.data = result._embedded.genericDataCollections;
         return result;
       }));
   }


### PR DESCRIPTION

## What does this PR do?

Following the changes made to `GenericDataCollection` data type in wipp-backend, the endpoints and properties of `GenericDataCollection` are renamed in this PR.

## Related issues

#207