### PR TITLE
fix: fixed navigation to plugin list page after deleting a plugin

### DIFF
--- a/projects/wipp-frontend-lib/src/lib/plugin/plugin-detail/plugin-detail.component.ts
+++ b/projects/wipp-frontend-lib/src/lib/plugin/plugin-detail/plugin-detail.component.ts
@@ -74,7 +74,7 @@ export class PluginDetailComponent implements OnInit, OnDestroy {
   deletePlugin(): void {
     if (confirm('Are you sure you want to delete the plugin ' + this.plugin.name + ' v' + this.plugin.version + '?')) {
       this.pluginService.deletePlugin(this.plugin).subscribe(plugin => {
-        this.router.navigate(['plugins']);
+        this.router.navigate([this.pluginService.getPluginsUiPath()]);
       });
     }
   }


### PR DESCRIPTION


## What does this PR do?

fixed navigation to plugin list page when using consuming the library from polus-wipp.

